### PR TITLE
Send over host changes to AUProximity

### DIFF
--- a/src/Electric.AUProximity/AUProximityListener.cs
+++ b/src/Electric.AUProximity/AUProximityListener.cs
@@ -23,8 +23,13 @@ namespace Electric.AUProximity
             _proximityHub.Clients.Group(e.Game.Code).GameStarted();
             _proximityHub.Clients.Group(e.Game.Code).MapChange(e.Game.Options.Map);
         }
-        
-        
+
+        [EventListener]
+        public void GameHostChangeEvent(IGameHostChangeEvent e)
+        {
+            _proximityHub.Clients.Group(e.Game.Code).HostChange(e.Host.Client.Name);
+        }
+
         [EventListener]
         public void OnPlayerMove(IPlayerMovementEvent e)
         {

--- a/src/Electric.AUProximity/Electric.AUProximity.csproj
+++ b/src/Electric.AUProximity/Electric.AUProximity.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <OutputType>Library</OutputType>
         <RootNamespace>Electric.AUProximity</RootNamespace>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Electric.AUProximity/Hub/IProximityHub.cs
+++ b/src/Electric.AUProximity/Hub/IProximityHub.cs
@@ -13,5 +13,6 @@ namespace Electric.AUProximity.Hub
         Task GameEnd();
         Task CommsSabotage(bool fix);
         Task MapChange(MapTypes id);
+        Task HostChange(string name);
     }
 }

--- a/src/Electric.AUProximity/Hub/ProximityHub.cs
+++ b/src/Electric.AUProximity/Hub/ProximityHub.cs
@@ -1,13 +1,28 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Impostor.Api.Games;
+using Impostor.Api.Games.Managers;
 
 namespace Electric.AUProximity.Hub
 {
     public class ProximityHub : Hub<IProximityHub>
     {
+        private readonly IGameManager _gameManager;
+
+        public ProximityHub(IGameManager gameManager)
+        {
+            _gameManager = gameManager;
+        }
+
         public async Task TrackGame(string gameCode)
         {
             await Groups.AddToGroupAsync(Context.ConnectionId, gameCode);
+            IGame? game = _gameManager.Find(gameCode);
+            if (game != null)
+            {
+                await this.Clients.Group(gameCode).MapChange(game.Options.Map);
+                await this.Clients.Group(gameCode).HostChange(game.Host.Client.Name);
+            }
         }
     }
 }

--- a/src/Impostor.Api/Events/Game/IGameHostChangeEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGameHostChangeEvent.cs
@@ -1,0 +1,9 @@
+using Impostor.Api.Net;
+
+namespace Impostor.Api.Events
+{
+    public interface IGameHostChangeEvent : IGameEvent
+    {
+        IClientPlayer Host { get; }
+    }
+}

--- a/src/Impostor.Server/Events/Game/GameHostChangeEvent.cs
+++ b/src/Impostor.Server/Events/Game/GameHostChangeEvent.cs
@@ -1,0 +1,19 @@
+using Impostor.Api.Events;
+using Impostor.Api.Games;
+using Impostor.Api.Net;
+
+namespace Impostor.Server.Events
+{
+    public class GameHostChangeEvent : IGameHostChangeEvent
+    {
+        public GameHostChangeEvent(IGame game, IClientPlayer host)
+        {
+            Game = game;
+            Host = host;
+        }
+
+        public IGame Game { get; }
+
+        public IClientPlayer Host { get; }
+    }
+}

--- a/src/Impostor.Server/Net/State/Game.State.cs
+++ b/src/Impostor.Server/Net/State/Game.State.cs
@@ -116,6 +116,8 @@ namespace Impostor.Server.Net.State
                 // Pull players out of limbo.
                 await CheckLimboPlayers();
             }
+
+            await _eventManager.CallAsync(new GameHostChangeEvent(this, Host));
         }
 
         private async ValueTask CheckLimboPlayers()


### PR DESCRIPTION
### Description

Currently the AUProximity plugin does not send over the host to AUProximity: this PR adds an event for that. This PR needs corresponding changes on the AUProximity side to work properly, which will be submitted immediately after this PR.

This PR contains a Pull Request for Impostor: it didn't have a HostChange event yet, so I added https://github.com/Impostor/Impostor/pull/277 to our fork of Impostor. Thanks 112batman!

Bonus feature: With this PR, the map is also sent over when you first set up the game, this used to only happen on game start.
<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->
